### PR TITLE
Drop `org.kde.*` own-name

### DIFF
--- a/net.hovancik.Stretchly.yaml
+++ b/net.hovancik.Stretchly.yaml
@@ -19,10 +19,7 @@ finish-args:
   - --socket=pulseaudio
   - --share=network
   - --talk-name=org.freedesktop.Notifications
-
-  # DBus permissions required for app indicator support.
-  # This wildcard permission is necessary for electron to create its own uniquely numbered org.kde.StatusNotifierItem name.
-  - --own-name=org.kde.*
+  # Tray on KDE
   - --talk-name=org.kde.StatusNotifierWatcher
 modules:
   - shared-modules/dbus-glib/dbus-glib.json


### PR DESCRIPTION
This is no longer required with newer Electron and runtime

https://docs.flatpak.org/en/latest/desktop-integration.html#statusnotifier

> Most implementations of StatusNotifer have dropped this requirement
> but known exceptions to this are Electron versions older than 23.3.0.

Current version uses Electron 25.0.1
https://github.com/hovancik/stretchly/blob/dff2e6b4bba2f43a6b05a58ad0580252db0110cc/package.json#L127