### PR TITLE
fix: add `system-bus` socket for idle detection in Flatpak

### DIFF
--- a/net.hovancik.Stretchly.yaml
+++ b/net.hovancik.Stretchly.yaml
@@ -17,6 +17,9 @@ finish-args:
   # - --socket=fallback-x11
   # - --socket=wayland
   - --socket=pulseaudio
+  # Access DBus for idle status
+  - --system-talk-name=org.freedesktop.Notifications
+  - --system-talk-name=org.xfce.Xfconf
   - --share=network
   - --talk-name=org.freedesktop.Notifications
   # Tray on KDE


### PR DESCRIPTION
The current flatpak can't access dbus, failing to detect Do Not Dirturb and throwing errors:

> [3:0116/084049.425437:ERROR:bus.cc(407)] Failed to connect to the bus: Failed to connect to socket /run/dbus/system_bus_socket: No such file or directory

This change adds the `system-bus` socket, and it runs without errors and successfully detects Do Not Disturb.