### PR TITLE
try to resolve issue https://github.com/hovancik/stretchly/issues/1693

### DIFF
--- a/net.hovancik.Stretchly.yaml
+++ b/net.hovancik.Stretchly.yaml
@@ -51,18 +51,7 @@ modules:
           - export TMPDIR=$XDG_CACHE_HOME
           - export ZYPAK_SPAWN_LATEST_ON_REEXEC=0
           - export CHROME_WRAPPER=/app/bin/run.sh
-          - |
-            FLAGS="$FLAGS --enable-features=UseOzonePlatform"
-            if [ -n "${WAYLAND_DISPLAY+set}" ] && [ -e "$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY" ]; then
-              echo "Wayland detected. Enabling Wayland support."
-              FLAGS="$FLAGS --ozone-platform=wayland"
-            else
-              echo "Wayland not detected. Enabling X11 support."
-              FLAGS="$FLAGS --ozone-platform=x11"
-            fi
-            echo "Stretchly flags: $FLAGS"
-            zypak-wrapper /app/main/stretchly $FLAGS "$@"
-
+          - zypak-wrapper /app/main/stretchly --ozone-platform=x11 "$@"
     build-commands:
       - |
         ln -s $XDG_CACHE_HOME/node-gyp $HOME/.electron-gyp


### PR DESCRIPTION
I think this is the simplest way to resolve the "Wayland doesn't have permission inside the flatpak" issue
https://github.com/hovancik/stretchly/issues/1693

Just assume the users will have X11 or XWayland, resolve all issues

The manifest currently comments out `--socket=wayland`, so of course `--ozone-platform=wayland` will fail?

Example failure:
```
anbernal@anbernal-thinkpadt14sgen2i:~$ flatpak run net.hovancik.Stretchly
WAYLAND_DISPLAY: wayland-0
XDG_RUNTIME_DIR: /run/user/4215325
app  bus  doc  flatpak-info  p11-kit  pulse
[4:1117/002546.213869:ERROR:dbus/bus.cc:408] Failed to connect to the bus: Failed to connect to socket /run/dbus/system_bus_socket: No such file or directory
[4:1117/002546.958812:ERROR:ui/ozone/platform/wayland/host/wayland_connection.cc:202] Failed to connect to Wayland display: No such file or directory (2)
```